### PR TITLE
move script tag to head

### DIFF
--- a/Casterr/Pages/_Host.cshtml
+++ b/Casterr/Pages/_Host.cshtml
@@ -15,14 +15,15 @@
   <meta http-equiv="Content-Security-Policy" content="script-src 'self';">
   <base href="~/" />
   <link href="css/Main.min.css" rel="stylesheet" />
+  
   <title>Casterr</title>
+  
+  <script src="_framework/blazor.server.js" defer></script>
+  <script src="js/scrolling.js" defer></script>
 </head>
 <body>
   <app>
     <component type="typeof(App)" render-mode="ServerPrerendered" />
   </app>
-
-  <script src="_framework/blazor.server.js"></script>
-  <script src="js/scrolling.js"></script>
 </body>
 </html>


### PR DESCRIPTION
"An old-fashioned solution to this problem used to be to put your script element right at the bottom of the body (e.g. just before the </body> tag), so that it would load after all the HTML has been parsed. The problem with this solution is that loading/parsing of the script is completely blocked until the HTML DOM has been loaded. On larger sites with lots of JavaScript, this can cause a major performance issue, slowing down your site."